### PR TITLE
Modular eye rendering + eyeType visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.1.8] - 2026-01-02
+### Added
+- Added a reusable eye renderer module for species-agnostic eye drawing
+### Changed
+- Eye rendering now supports distinct `eyeType` visuals (sleepy, sparkly flash accents, winking animation)
+- Sparkly eyes now flash briefly instead of staying visible between flashes
+- Fish rendering now flips horizontally on leftward movement and clamps visual pitch to ±65°
+### Fixed
+- Fish no longer render upside down when swimming left
+
 ## [0.1.7] - 2025-12-31
 ### Changed
 - Bumped app version to 0.1.7

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,17 @@
 - TODO (duplication): Remove direct `storageManager.save()` calls from UI fallbacks once GameState path is unified.
 - Record: update `CHANGELOG.md` and `TODO.md` with cleanup results.
 
+## Eye rendering modularization + eyeType visuals (Issue #16)
+
+- DONE: Extract eye drawing from `src/entities/fish.ts` into a reusable renderer module (species-agnostic).
+- DONE: Keep eyeType values: `round`, `sleepy`, `sparkly`, `winking` (no new values yet).
+- DONE: Implement `round`: current default.
+- DONE: Implement `sleepy`: half-closed lid look with lower eye visible.
+- DONE: Implement `sparkly`: flash-only sparkle accents; +1px radius once size >= 10.
+- DONE: Implement `winking`: deterministic phase (no per-fish timers), ~1s closed, ~10s open.
+- DONE: Ensure eye size scales with fish size/age and supports future two-eye species.
+- DONE: Wire fish rendering to the new eye module and verify visuals in-game.
+
 ## Storage / validation flow concerns (high priority)
 
 - DONE: Confirmed `fishCollection` will evolve into `bioInventory` (schema/validator work deferred).

--- a/docs/ActiveFiles.txt
+++ b/docs/ActiveFiles.txt
@@ -82,7 +82,7 @@ The application is moving toward a centralized persistence model where:
    * REQUIRES: (none)
    * USED-BY: src/state/types.ts
  - src/entities/fish.ts - Fish entity logic and behavior
-   * REQUIRES: src/state/GameState.ts, src/ui/FishCollection.ts (dynamic), src/ui/toast.ts, src/utils/audio.ts
+   * REQUIRES: src/state/GameState.ts, src/render/eyeRenderer.ts, src/ui/FishCollection.ts (dynamic), src/ui/toast.ts, src/utils/audio.ts
    * USED-BY: src/legacy/runLegacyGame.ts
    * PERSISTENCE: Updates in-memory data only
  - src/entities/decor.ts - Decorations and environment
@@ -123,6 +123,9 @@ The application is moving toward a centralized persistence model where:
   * REQUIRES: src/state/types.ts
   * USED-BY: src/legacy/runLegacyGame.ts
   * NOTES: Debug decor radius overlay toggled by settings.debugDecorRadius
+- src/render/eyeRenderer.ts - Eye drawing helpers (species-agnostic)
+  * REQUIRES: (none)
+  * USED-BY: src/entities/fish.ts
 
 ## Configuration
 - src/config/gameConfig.ts - Game title/version/config values

--- a/meta.txt
+++ b/meta.txt
@@ -1,6 +1,6 @@
 name: "Carole's Reef",
 path: "Caroles_Reef/",
 thumb: "Caroles_Reef/caroles_reef-thumb-01.png",
-version: "0.1.7",
+version: "0.1.8",
 desc: "Genetic exploration in a chill saltwater reef",
 modified: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caroles_reef",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "caroles_reef",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "license": "AGPL",
       "dependencies": {
         "howler": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caroles_reef",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A relaxing virtual aquarium where you can breed and care for beautiful tropical fish",
   "type": "module",
   "main": "src/main.ts",

--- a/src/render/eyeRenderer.ts
+++ b/src/render/eyeRenderer.ts
@@ -1,0 +1,244 @@
+// src/render/eyeRenderer.ts
+
+export type EyeRenderParams = {
+  ctx: CanvasRenderingContext2D;
+  eyeType?: string;
+  x: number;
+  y: number;
+  bodyLen: number;
+  bodyHt: number;
+  size?: number;
+  colorHue?: number;
+  timeMs?: number;
+  idSeed?: string | number;
+};
+
+const WINK_CLOSED_MS = 1000;
+const WINK_OPEN_MS = 10000;
+const WINK_CLOSE_MS = 200;
+const WINK_OPENING_MS = 200;
+const WINK_CYCLE_MS = WINK_CLOSED_MS + WINK_OPEN_MS;
+
+const TWINKLE_MIN = 0;
+const TWINKLE_MAX = 1;
+
+export function drawEye(params: EyeRenderParams) {
+  const {
+    ctx,
+    eyeType,
+    x,
+    y,
+    bodyHt,
+    size,
+    timeMs = typeof performance !== 'undefined' ? performance.now() : Date.now(),
+    idSeed,
+  } = params;
+
+  const type = eyeType || 'round';
+  const baseRadius = Math.max(2, bodyHt * 0.12);
+  const pupilBase = Math.max(1, bodyHt * 0.06);
+  const sparkleBoost = type === 'sparkly' && typeof size === 'number' && size >= 10 ? 1 : 0;
+  const radius = baseRadius + sparkleBoost;
+  const phaseMs = phaseOffsetMs(timeMs, idSeed);
+
+  if (type === 'winking') {
+    const lid = winkLidAmount(phaseMs);
+    drawEyeOpen(ctx, x, y, radius, 1 - 0.85 * lid);
+    if (lid < 0.7) {
+      drawPupil(ctx, x, y, pupilBase);
+    }
+    if (lid > 0.6) {
+      drawClosedLid(ctx, x, y, radius);
+    }
+    return;
+  }
+
+  drawEyeOpen(ctx, x, y, radius, 1);
+
+  if (type === 'sleepy') {
+    drawSleepyEye(ctx, x, y, radius, pupilBase, bodyHt, params.colorHue);
+    return;
+  }
+
+  if (type === 'sparkly') {
+    drawSparkleSpecks(ctx, x, y, radius, phaseMs);
+    drawPupil(ctx, x, y, Math.max(1, pupilBase * 1.25));
+    drawSparkleHighlights(ctx, x, y, radius, phaseMs);
+  } else {
+    drawPupil(ctx, x, y, pupilBase);
+  }
+}
+
+function phaseOffsetMs(timeMs: number, seed?: string | number) {
+  if (seed == null) return timeMs % WINK_CYCLE_MS;
+  const offset = hashToUnit(seed) * WINK_CYCLE_MS;
+  return (timeMs + offset) % WINK_CYCLE_MS;
+}
+
+function winkLidAmount(phaseMs: number) {
+  if (phaseMs >= WINK_CLOSED_MS) return 0;
+  if (phaseMs < WINK_CLOSE_MS) return phaseMs / WINK_CLOSE_MS;
+  if (phaseMs < WINK_CLOSED_MS - WINK_OPENING_MS) return 1;
+  return 1 - (phaseMs - (WINK_CLOSED_MS - WINK_OPENING_MS)) / WINK_OPENING_MS;
+}
+
+function drawEyeOpen(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  scaleY: number
+) {
+  const clampedScale = Math.max(0.15, Math.min(1, scaleY));
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.scale(1, clampedScale);
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawPupil(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number) {
+  ctx.fillStyle = '#000';
+  ctx.beginPath();
+  ctx.arc(x + 1, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+function drawSleepyEye(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  pupilRadius: number,
+  bodyHt: number,
+  colorHue?: number
+) {
+  const lidY = y - radius * 0.15;
+  const lidColor = typeof colorHue === 'number' ? `hsl(${colorHue} 55% 30%)` : 'rgba(0,0,0,0.45)';
+
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x - radius * 1.2, y, radius * 2.4, radius * 2);
+  ctx.clip();
+  drawPupil(ctx, x, y + radius * 0.25, Math.max(1, pupilRadius * 0.8));
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalAlpha = 0.6;
+  ctx.fillStyle = lidColor;
+  ctx.beginPath();
+  ctx.arc(x, lidY, radius * 1.05, Math.PI, 0, false);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = Math.max(1, bodyHt * 0.02);
+  ctx.beginPath();
+  ctx.arc(x, lidY, radius * 0.95, Math.PI * 0.12, Math.PI * 0.88);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawClosedLid(ctx: CanvasRenderingContext2D, x: number, y: number, radius: number) {
+  ctx.save();
+  ctx.strokeStyle = '#000';
+  ctx.lineWidth = Math.max(1, radius * 0.12);
+  ctx.beginPath();
+  ctx.arc(x, y, radius * 0.9, Math.PI * 0.2, Math.PI * 0.8);
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawSparkleSpecks(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  phaseMs: number
+) {
+  const phase = (phaseMs % WINK_CYCLE_MS) / WINK_CYCLE_MS;
+  const flash = flashAlpha(phase);
+  const alpha = TWINKLE_MIN + (TWINKLE_MAX - TWINKLE_MIN) * flash;
+  if (alpha <= 0.02) return;
+  const spark = Math.max(4, radius * 2.4);
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = Math.max(1, radius * 0.28);
+
+  ctx.beginPath();
+  ctx.moveTo(x - spark, y);
+  ctx.lineTo(x + spark, y);
+  ctx.moveTo(x, y - spark);
+  ctx.lineTo(x, y + spark);
+  ctx.stroke();
+
+  const dx = -radius * 0.75;
+  const dy = -radius * 0.75;
+  const sparkSmall = spark * 0.6;
+  ctx.beginPath();
+  ctx.moveTo(x + dx - sparkSmall, y + dy);
+  ctx.lineTo(x + dx + sparkSmall, y + dy);
+  ctx.moveTo(x + dx, y + dy - sparkSmall);
+  ctx.lineTo(x + dx, y + dy + sparkSmall);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.4, y + radius * 0.3, Math.max(3, radius * 0.45), 0, Math.PI * 2);
+  ctx.arc(x + radius * 0.25, y + radius * 0.5, Math.max(3, radius * 0.35), 0, Math.PI * 2);
+  ctx.arc(x + radius * 1.25, y - radius * 0.2, Math.max(3, radius * 0.3), 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function drawSparkleHighlights(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  phaseMs: number
+) {
+  const phase = (phaseMs % WINK_CYCLE_MS) / WINK_CYCLE_MS;
+  const alpha = flashAlpha(phase);
+  if (alpha <= 0.02) return;
+  ctx.save();
+  ctx.globalAlpha = Math.max(0.15, alpha);
+  ctx.fillStyle = '#fff';
+  ctx.beginPath();
+  ctx.arc(x - radius * 0.32, y - radius * 0.32, Math.max(1, radius * 0.22), 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.globalAlpha = Math.max(0.12, alpha * 0.7);
+  ctx.beginPath();
+  ctx.arc(x + radius * 0.12, y - radius * 0.08, Math.max(1, radius * 0.16), 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+}
+
+function hashToUnit(seed: string | number) {
+  const str = String(seed);
+  let hash = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967295;
+}
+
+function flashAlpha(phase: number) {
+  const flashWidth = 0.08;
+  const center = 0.15;
+  const dist = Math.abs(phase - center);
+  const pulse = Math.max(0, 1 - dist / flashWidth);
+  return pulse * pulse;
+}


### PR DESCRIPTION
## Summary\n- Extracted eye rendering into a reusable module and wired fish drawing to it\n- Implemented distinct eyeType visuals (sleepy, sparkly flash accents, winking animation)\n- Added left-facing flip and clamped visual pitch to keep fish upright\n- Bumped version to 0.1.8 and documented updates\n\n## Testing\n- npm run lint\n- npm test\n- npm run build\n\nCloses #16